### PR TITLE
Use ScriptableObject.CreateInstance instead of new

### DIFF
--- a/LCAPI.TerminalCommands/Models/TerminalCommand.cs
+++ b/LCAPI.TerminalCommands/Models/TerminalCommand.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using BepInEx.Logging;
 using LCAPI.TerminalCommands.Attributes;
+using UnityEngine;
 
 namespace LCAPI.TerminalCommands.Models
 {
@@ -212,11 +213,11 @@ namespace LCAPI.TerminalCommands.Models
 				return (TerminalNode)result;
 			}
 
-			return new TerminalNode()
-			{
-				displayText = result.ToString() + '\n',
-				clearPreviousText = ClearConsole
-			};
+			var response = ScriptableObject.CreateInstance<TerminalNode>();
+			response.displayText = result.ToString() + '\n';
+			response.clearPreviousText = ClearConsole;
+
+			return response;
 		}
 	}
 }


### PR DESCRIPTION
Very simple and minor "fix".

See for context: https://github.com/JetBrains/resharper-unity/wiki/ScriptableObjects-must-be-instantiated-with-ScriptableObject.CreateInstance-instead-of-new